### PR TITLE
chore(pyproject): disable COM812 ruff rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,9 @@ dev = [
 [tool.ruff.lint]
 select = ["ALL"]
 
+ignore = [
+    "COM812",  # in conflict with formatter
+]
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
From the docs [1]:

> We recommend against using this rule alongside the formatter.
  The formatter enforces consistent use of trailing commas,
  making the rule redundant.

Fixes the following warning:

    warning: The following rule may cause conflicts when used with
    the formatter: `COM812`. To avoid unexpected behavior, we
    recommend disabling this rule, either by removing it from the
    `lint.select` or `lint.extend-select` configuration, or adding
    it to the `lint.ignore` configuration.

1. https://docs.astral.sh/ruff/rules/missing-trailing-comma/