### PR TITLE
chore(CI): Change include to package in pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,8 @@ license = "MIT"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-
 [tool.hatch.build.targets.wheel]
-include = ["src/em511"]
+packages = ["src/em511"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
I did this to shorten the import path from src/em511 to em511 only.